### PR TITLE
ブログ記事のテンプレートを追加

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,0 +1,33 @@
+import React from "react"
+import Link from "gatsby-link"
+import { graphql } from "gatsby"
+
+export default function Template({ data }) {
+  const post = data.markdownRemark
+
+  return (
+    <div>
+      <Link to="/blog">Go Back</Link>
+      <hr />
+      <h1>{post.frontmatter.title}</h1>
+      <h4>
+        Posted by {post.frontmatter.author} on {post.frontmatter.date}
+      </h4>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} />
+    </div>
+  )
+}
+
+export const postQuery = graphql`
+  query BlogPostByPath($path: String!) {
+    markdownRemark(frontmatter: { path: { eq: $path } }) {
+      html
+      frontmatter {
+        path
+        title
+        author
+        date
+      }
+    }
+  }
+`


### PR DESCRIPTION
## チケットへのリンク
チケットなし

## 変更の概要
* 変更の概要
ブログ記事のテンプレートを作成。

* 関連するIssueやプルリクエスト

## コード詳細
タイトル、著者、日付をMarkdownで表示。

`dangerouslySetInnerHTML`
マークダウン
ブラウザ上で記述したHTMLのプレビューなどを作る場合に使われるケースが多い。
`__html` propertyをもつobjectを渡すことで実行される。

今回はvariable postがdata.markdownRemarkなので、`__html` objectをもつpropertyは`post.html`


参考：https://bit.ly/3pZVzGY



