### PR TITLE
Feature/006 create page api

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,8 +13,8 @@
 
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const postTemplate = path.resolve("src/templates/blog-post.js")
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,4 +4,62 @@
  * See: https://www.gatsbyjs.com/docs/node-apis/
  */
 
-// You can delete this file if you're not using it
+/**
+ * ここで1ページあたりの投稿を2つ、特定の記事の詳細が見れるようにする
+ * pathを作る感じ。
+ *
+ * ※振り返り用にコメントを残している
+ */
+
+const path = require("path")
+
+exports.createPages = ({ boundActionCreators, graphql }) => {
+  const { createPage } = boundActionCreators
+
+  const postTemplate = path.resolve("src/templates/blog-post.js")
+
+  return graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            html
+            id
+            frontmatter {
+              path
+              title
+              date
+              author
+            }
+          }
+        }
+      }
+    }
+  `).then(res => {
+    if (res.errors) {
+      return Promise.reject(res.errors)
+    }
+
+    res.data.allMarkdownRemark.edges.forEach(({ node }) => {
+      createPage({
+        path: node.frontmatter.path,
+        component: postTemplate,
+      })
+    })
+  })
+}
+
+/**
+ * 「Promiseを使った表示制御について」
+ * エラーチェックの応答
+ * エラーが発生した場合は、戻る
+ * エラーがなければ問題なくデータを返す
+ * ループ処理をする
+ *
+ */
+
+// ここを書き換える時は、必ずterminalを止めてから再度スタートさせること
+
+// htmlとIDを加えた理由は？
+
+// graph qlのexpertって何者？

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,6 +49,8 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
   })
 }
 
+// Pull request前にコメントは削除
+
 /**
  * 「Promiseを使った表示制御について」
  * エラーチェックの応答
@@ -58,8 +60,11 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
  *
  */
 
-// ここを書き換える時は、必ずterminalを止めてから再度スタートさせること
+// gatsby-node.jsを書き換える時は、必ずterminalを止めてから再度スタートさせること
 
-// htmlとIDを加えた理由は？
-
-// graph qlのexpertって何者？
+/** htmlとIDとは？
+ * html : text data
+ * ID : UniqueなdataのID
+ *
+ *
+ */

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -44,3 +44,11 @@ export const pageQuery = graphql`
 `
 
 export default BlogPage
+
+// graph qlのexcerptって何者？
+/* 語源：（たくさんある中から）選んでつまみ取る
+ *
+ * text dataを抜粋する役割
+ *
+ *
+ */

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Link } from "gatsby"
+// import { Link } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
 
 import Layout from "../components/layout"


### PR DESCRIPTION
gatsby-node.js PageApiを作っています。

http://localhost:8000/blog ページから、Markdown fileにアクセスして、Read more textを押すと指定した記事が表示される仕様を実装しようとしています。

Variableのpathは、require methodsでpath moduleを取得しています。ここで取得したいpath moduleは、pages folderの2018-04-09-post-one下のindex.md内にあるpathを指しています。

つづいて、createPages propertyの中身を説明します。actions argumentをcreatePage variableに入れることで、forEach methodsで実装するGraphQLのデータを使ってページを追加する処理が使えるようにしています。

※actions argumentは、元々getPathAndBlogTemplatesという名前にしていました。エラーがでてしまったので、調べた時に出てきたactionsをそのまま使ってみたらエラーがなくなったのでひとまずこのままactionsという名前を使っています。

actions argumentは、GraphQLでデータを取得するのに使うためのものです。

postTemplate variableは、表示したい記事のtemplateのpathを入れています。path.resolve()としているのは、調べてみるとこう書くことで取得できそうだったのでそのまま真似しました。
参考：https://bit.ly/2Sc0Zm0

graphqlの中身は、取得したい記事情報を表示させたい場合、このような形になりました。（GraphiQLを使用） 参考：http://localhost:8000/___graphql

Promiseを使っているのは、表示させたいページが表示できない時、エラーを返す仕様にしたかったので使いました。

forEach methodsは、表示させたいページのpathと記事templateを表しています。


メンタリング用のコメントをそのまま活用して時間短縮。